### PR TITLE
fix notebook alignment

### DIFF
--- a/notebooks/examples/alignment_using_landmarks.ipynb
+++ b/notebooks/examples/alignment_using_landmarks.ipynb
@@ -39,13 +39,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "9b33ec76",
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-04-10T18:53:42.780777Z",
-     "start_time": "2023-04-10T18:53:42.778038Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -58,56 +54,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "74cb18bf",
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-04-10T16:39:12.804097Z",
-     "start_time": "2023-04-10T16:39:09.756352Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/macbook/miniconda3/envs/ome/lib/python3.10/site-packages/anndata/_core/anndata.py:183: ImplicitModificationWarning: Transforming to str index.\n",
-      "  warnings.warn(\"Transforming to str index.\", ImplicitModificationWarning)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "SpatialData object with:\n",
-       "├── Images\n",
-       "│     ├── 'morphology_focus': MultiscaleSpatialImage[cyx] (1, 25778, 35416), (1, 12889, 17708), (1, 6444, 8854), (1, 3222, 4427), (1, 1611, 2213)\n",
-       "│     └── 'morphology_mip': MultiscaleSpatialImage[cyx] (1, 25778, 35416), (1, 12889, 17708), (1, 6444, 8854), (1, 3222, 4427), (1, 1611, 2213)\n",
-       "├── Points\n",
-       "│     └── 'transcripts': DataFrame with shape: (42638083, 8) (3D points)\n",
-       "├── Shapes\n",
-       "│     ├── 'cell_boundaries': GeoDataFrame shape: (167780, 1) (2D shapes)\n",
-       "│     ├── 'cell_circles': GeoDataFrame shape: (167780, 2) (2D shapes)\n",
-       "│     ├── 'nucleus_boundaries': GeoDataFrame shape: (167780, 1) (2D shapes)\n",
-       "│     └── 'xenium_landmarks': GeoDataFrame shape: (3, 2) (2D shapes)\n",
-       "└── Table\n",
-       "      └── AnnData object with n_obs × n_vars = 167780 × 313\n",
-       "    obs: 'cell_id', 'transcript_counts', 'control_probe_counts', 'control_codeword_counts', 'total_counts', 'cell_area', 'nucleus_area', 'region'\n",
-       "    var: 'gene_ids', 'feature_types', 'genome'\n",
-       "    uns: 'spatialdata_attrs'\n",
-       "    obsm: 'spatial': AnnData (167780, 313)\n",
-       "with coordinate systems:\n",
-       "▸ 'aligned', with elements:\n",
-       "        morphology_mip (Images)\n",
-       "▸ 'global', with elements:\n",
-       "        morphology_focus (Images), morphology_mip (Images), transcripts (Points), cell_boundaries (Shapes), cell_circles (Shapes), nucleus_boundaries (Shapes), xenium_landmarks (Shapes)"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xenium_sdata = sd.read_zarr(\"xenium.zarr\")\n",
     "xenium_sdata"
@@ -115,52 +67,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "53b923aa",
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-04-10T16:39:26.103792Z",
-     "start_time": "2023-04-10T16:39:25.844959Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "SpatialData object with:\n",
-       "├── Images\n",
-       "│     ├── 'CytAssist_FFPE_Human_Breast_Cancer_full_image': MultiscaleSpatialImage[cyx] (3, 21571, 19505), (3, 10785, 9752), (3, 5392, 4876), (3, 2696, 2438), (3, 1348, 1219)\n",
-       "│     ├── 'CytAssist_FFPE_Human_Breast_Cancer_hires_image': SpatialImage[cyx] (3, 2000, 1809)\n",
-       "│     └── 'CytAssist_FFPE_Human_Breast_Cancer_lowres_image': SpatialImage[cyx] (3, 600, 543)\n",
-       "├── Points\n",
-       "│     ├── 'Points': DataFrame with shape: (3, 2) (2D points)\n",
-       "│     └── 'Points_1': DataFrame with shape: (1, 2) (2D points)\n",
-       "├── Shapes\n",
-       "│     ├── 'CytAssist_FFPE_Human_Breast_Cancer': GeoDataFrame shape: (4992, 2) (2D shapes)\n",
-       "│     └── 'visium_landmarks': GeoDataFrame shape: (3, 2) (2D shapes)\n",
-       "└── Table\n",
-       "      └── AnnData object with n_obs × n_vars = 4992 × 18085\n",
-       "    obs: 'in_tissue', 'array_row', 'array_col', 'spot_id', 'region', 'dataset', 'clone'\n",
-       "    var: 'gene_ids', 'feature_types', 'genome'\n",
-       "    uns: 'spatial', 'spatialdata_attrs'\n",
-       "    obsm: 'spatial': AnnData (4992, 18085)\n",
-       "with coordinate systems:\n",
-       "▸ 'aligned', with elements:\n",
-       "        CytAssist_FFPE_Human_Breast_Cancer_full_image (Images), Points (Points), Points_1 (Points), CytAssist_FFPE_Human_Breast_Cancer (Shapes), visium_landmarks (Shapes)\n",
-       "▸ 'downscaled_hires', with elements:\n",
-       "        CytAssist_FFPE_Human_Breast_Cancer_hires_image (Images), CytAssist_FFPE_Human_Breast_Cancer (Shapes)\n",
-       "▸ 'downscaled_lowres', with elements:\n",
-       "        CytAssist_FFPE_Human_Breast_Cancer_lowres_image (Images), CytAssist_FFPE_Human_Breast_Cancer (Shapes)\n",
-       "▸ 'global', with elements:\n",
-       "        CytAssist_FFPE_Human_Breast_Cancer_full_image (Images), CytAssist_FFPE_Human_Breast_Cancer (Shapes), visium_landmarks (Shapes)"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "visium_sdata = sd.read_zarr(\"visium.zarr\")\n",
     "visium_sdata"
@@ -248,13 +160,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "9d6ba021",
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-04-10T18:56:53.392894Z",
-     "start_time": "2023-04-10T18:56:53.353994Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -286,30 +194,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "d8f6dff4-ff07-495d-b29f-1e20e3f49d84",
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-04-10T19:09:31.490570Z",
-     "start_time": "2023-04-10T19:09:31.453640Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Affine (x, y -> x, y)\n",
-       "    [ 1.61711846e-01  2.58258090e+00 -1.24575040e+04]\n",
-       "    [-2.58258090e+00  1.61711846e-01  3.98647301e+04]\n",
-       "    [0. 0. 1.]"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from spatialdata.transformations import (\n",
     "    align_elements_using_landmarks,\n",
@@ -334,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "e71718a2",
    "metadata": {
     "collapsed": false,
@@ -343,23 +233,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Sequence \n",
-       "    Identity \n",
-       "    Affine (x, y -> x, y)\n",
-       "        [ 1.61711846e-01  2.58258090e+00 -1.24575040e+04]\n",
-       "        [-2.58258090e+00  1.61711846e-01  3.98647301e+04]\n",
-       "        [0. 0. 1.]"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "affine = align_elements_using_landmarks(\n",
     "    references_coords=xenium_sdata[\"xenium_landmarks\"],\n",
@@ -433,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "5c442fdb-94a9-488c-8d87-cfcc109f9388",
    "metadata": {
     "tags": []
@@ -517,7 +391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "474410bd-2d02-45c1-b073-eba1152ab615",
    "metadata": {
     "tags": []


### PR DESCRIPTION
This updates the notebook so that `add_...` is not used anymore for adding elements. Also at 2 places the commands for `napari-spatialdata` are updated to actually readily show the view that is displayed in the picture. The pictures are outdated as it displays old interface without the widget. We should probably still update this so not to confuse the user.