### PR TITLE
fix alignment notebook

### DIFF
--- a/datasets/README.md
+++ b/datasets/README.md
@@ -49,11 +49,19 @@ Also, here you can find [additional datasets and resources for methods developer
 If you use the datasets please cite the original sources and double-check their license.
 
 [^1]: He, S. et al. High-Plex Multiomic Analysis in FFPE Tissue at Single-Cellular and Subcellular Resolution by Spatial Molecular Imaging. bioRxiv 2021.11.03.467020 (2021) doi:10.1101/2021.11.03.467020.
+
 [^2]: From https://www.10xgenomics.com/datasets/visium-hd-cytassist-gene-expression-libraries-of-mouse-intestine
+
 [^3]: Janesick, A. et al. High resolution mapping of the breast cancer tumor microenvironment using integrated single cell, spatial and in situ analysis of FFPE tissue. bioRxiv 2022.10.06.510405 (2022) doi:10.1101/2022.10.06.510405.
+
 [^4]: Schapiro, D. et al. MCMICRO: A scalable, modular image-processing pipeline for multiplexed tissue imaging. Cold Spring Harbor Laboratory 2021.03.15.435473 (2021) doi:10.1101/2021.03.15.435473.
+
 [^5]: Moffitt, J. R. et al. Molecular, spatial, and functional single-cell profiling of the hypothalamic preoptic region. Science 362, (2018).
+
 [^6]: Hartmann, F. J. et al. Single-cell metabolic profiling of human cytotoxic T cells. Nat. Biotechnol. (2020) doi:10.1038/s41587-020-0651-8.
+
 [^7]: Windhager, J., Bodenmiller, B. & Eling, N. An end-to-end workflow for multiplexed image processing and analysis. bioRxiv 2021.11.12.468357 (2021) doi:10.1101/2021.11.12.468357.
+
 [^8]: Eling, N. & Windhager, J. Example imaging mass cytometry raw data. (2022). doi:10.5281/zenodo.5949116.
+
 [^9]: Eling, N. & Windhager, J. steinbock results of IMC example data. (2022). doi:10.5281/zenodo.7412972.

--- a/notebooks/examples/alignment_using_landmarks.ipynb
+++ b/notebooks/examples/alignment_using_landmarks.ipynb
@@ -177,9 +177,7 @@
      "outputs_hidden": false
     }
    },
-   "source": [
-    "Interactive([visium_sdata, xenium_sdata], points=False, shapes=False)"
-   ]
+   "source": "Interactive([visium_sdata, xenium_sdata])"
   },
   {
    "cell_type": "markdown",
@@ -352,7 +350,7 @@
     "affine = align_elements_using_landmarks(\n",
     "    references_coords=xenium_sdata[\"xenium_landmarks\"],\n",
     "    moving_coords=visium_sdata[\"visium_landmarks\"],\n",
-    "    reference_element=xenium_sdata[\"morphology_mip\"],\n",
+    "    reference_element=xenium_sdata[\"morphology_focus\"],\n",
     "    moving_element=visium_sdata[\"CytAssist_FFPE_Human_Breast_Cancer_full_image\"],\n",
     "    reference_coordinate_system=\"global\",\n",
     "    moving_coordinate_system=\"global\",\n",
@@ -375,9 +373,7 @@
    "metadata": {
     "tags": []
    },
-   "source": [
-    "Interactive([visium_sdata, xenium_sdata], points=False, shapes=False)"
-   ]
+   "source": "Interactive([visium_sdata, xenium_sdata])"
   },
   {
    "cell_type": "markdown",
@@ -500,17 +496,9 @@
    "id": "2e98374c-85cd-45ad-ac62-b2bc075c9631",
    "metadata": {},
    "source": [
-    "We will now save the landmark points and the transformations of the other elements to disk. \n",
+    "We will now save the landmark points and the transformations of the other elements to disk. First we write the elements to disk and then the transformations.\n",
     "\n",
     "Notice that these are both lightweight operations because the two sets of landmark points are small, and when saving the transformation of the other elements we are modifying the objects metadata, not transforming the actual data. This is useful when dealing with large images and when one may need to reiterate multiple steps of landmark-based alignment in order to improve the spatial agreement of the alignment."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a30ee131-40a4-44a2-b736-763532cf570e",
-   "metadata": {},
-   "source": [
-    "Note: the ability to save transformations on disk is, at the time of writing, not released yet in `PyPi`; nevertheless, the implementation is already fully available at https://github.com/scverse/spatialdata/pull/501."
    ]
   },
   {
@@ -535,6 +523,8 @@
    "source": [
     "from spatialdata import save_transformations\n",
     "\n",
+    "visium_sdata.write_element(\"visium_landmarks\")\n",
+    "xenium_sdata.write_element(\"xenium_landmarks\")\n",
     "visium_sdata.write_transformations()\n",
     "xenium_sdata.write_transformations()"
    ]


### PR DESCRIPTION
Couple of fixes with the alignment notebook. First of all xenium does not contain `morphology_mip` so switched to `morphology_focus`. Also removed `points` and `shapes` arguments from `Interactive` as `Interactive` does not have these parameters. Lastly, added `write_element` and removed part of the explanation that incremental io is not implemented.