### PR TITLE
add comment to link to spatialdata object

### DIFF
--- a/notebooks/examples/alignment_using_landmarks.ipynb
+++ b/notebooks/examples/alignment_using_landmarks.ipynb
@@ -38,58 +38,124 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
+   "execution_count": 1,
+   "id": "1f53261205fc9441",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/miniconda3/envs/ome/lib/python3.10/site-packages/numba/core/decorators.py:246: RuntimeWarning: nopython is set for njit and is ignored\n",
+      "  warnings.warn('nopython is set for njit and is ignored', RuntimeWarning)\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "import spatialdata as sd\n",
     "from napari_spatialdata import Interactive"
-   ],
-   "id": "1f53261205fc9441"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
+   "execution_count": 2,
+   "id": "b688e9cd77be1055",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SpatialData object, with associated Zarr store: /Users/macbook/embl/projects/basel/spatialdata-sandbox/xenium_rep1_io/data.zarr\n",
+       "├── Images\n",
+       "│     ├── 'morphology_focus': DataTree[cyx] (1, 25778, 35416), (1, 12889, 17708), (1, 6444, 8854), (1, 3222, 4427), (1, 1611, 2213)\n",
+       "│     └── 'morphology_mip': DataTree[cyx] (1, 25778, 35416), (1, 12889, 17708), (1, 6444, 8854), (1, 3222, 4427), (1, 1611, 2213)\n",
+       "├── Points\n",
+       "│     ├── 'transcripts': DataFrame with shape: (<Delayed>, 8) (3D points)\n",
+       "│     └── 'xenium_landmarks': DataFrame with shape: (<Delayed>, 2) (2D points)\n",
+       "├── Shapes\n",
+       "│     ├── 'Shapes': GeoDataFrame shape: (4, 1) (2D shapes)\n",
+       "│     ├── 'cell_boundaries': GeoDataFrame shape: (167780, 1) (2D shapes)\n",
+       "│     └── 'cell_circles': GeoDataFrame shape: (167780, 2) (2D shapes)\n",
+       "└── Tables\n",
+       "      ├── 'annotation_Shapes': AnnData (4, 0)\n",
+       "      └── 'table': AnnData (167780, 313)\n",
+       "with coordinate systems:\n",
+       "    ▸ 'aligned', with elements:\n",
+       "        morphology_focus (Images), morphology_mip (Images), transcripts (Points), cell_boundaries (Shapes), cell_circles (Shapes)\n",
+       "    ▸ 'global', with elements:\n",
+       "        morphology_focus (Images), morphology_mip (Images), transcripts (Points), xenium_landmarks (Points), Shapes (Shapes), cell_boundaries (Shapes), cell_circles (Shapes)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "xenium_sdata = sd.read_zarr(\"xenium.zarr\")\n",
     "xenium_sdata"
-   ],
-   "id": "b688e9cd77be1055"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
+   "execution_count": 3,
+   "id": "934577dfc660308c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SpatialData object, with associated Zarr store: /Users/macbook/embl/projects/basel/spatialdata-sandbox/visium_associated_xenium_io/data.zarr\n",
+       "├── Images\n",
+       "│     ├── 'CytAssist_FFPE_Human_Breast_Cancer_full_image': DataTree[cyx] (3, 21571, 19505), (3, 10785, 9752), (3, 5392, 4876), (3, 2696, 2438), (3, 1348, 1219)\n",
+       "│     ├── 'CytAssist_FFPE_Human_Breast_Cancer_hires_image': DataArray[cyx] (3, 2000, 1809)\n",
+       "│     └── 'CytAssist_FFPE_Human_Breast_Cancer_lowres_image': DataArray[cyx] (3, 600, 543)\n",
+       "├── Points\n",
+       "│     └── 'visium_landmarks': DataFrame with shape: (<Delayed>, 2) (2D points)\n",
+       "├── Shapes\n",
+       "│     └── 'CytAssist_FFPE_Human_Breast_Cancer': GeoDataFrame shape: (4992, 2) (2D shapes)\n",
+       "└── Tables\n",
+       "      └── 'table': AnnData (4992, 18085)\n",
+       "with coordinate systems:\n",
+       "    ▸ 'aligned', with elements:\n",
+       "        CytAssist_FFPE_Human_Breast_Cancer_full_image (Images), CytAssist_FFPE_Human_Breast_Cancer (Shapes)\n",
+       "    ▸ 'downscaled_hires', with elements:\n",
+       "        CytAssist_FFPE_Human_Breast_Cancer_hires_image (Images), CytAssist_FFPE_Human_Breast_Cancer (Shapes)\n",
+       "    ▸ 'downscaled_lowres', with elements:\n",
+       "        CytAssist_FFPE_Human_Breast_Cancer_lowres_image (Images), CytAssist_FFPE_Human_Breast_Cancer (Shapes)\n",
+       "    ▸ 'global', with elements:\n",
+       "        CytAssist_FFPE_Human_Breast_Cancer_full_image (Images), visium_landmarks (Points), CytAssist_FFPE_Human_Breast_Cancer (Shapes)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "visium_sdata = sd.read_zarr(\"visium.zarr\")\n",
     "visium_sdata"
-   ],
-   "id": "934577dfc660308c"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "12c5b4809c9be7ec",
+   "metadata": {},
    "source": [
     "Let's visualize the data with napari.\n",
     "\n",
     "*Note: we are working with the napari developers to improve performance when visualizing large collections of geometries. For the sake of this example let's just show the Xenium and Visium images.*"
-   ],
-   "id": "12c5b4809c9be7ec"
+   ]
   },
   {
+   "cell_type": "raw",
+   "id": "581982a1-a0c9-428c-ad22-61e659e7f66d",
    "metadata": {},
-   "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "Interactive([visium_sdata, xenium_sdata])"
-   ],
-   "id": "cc89e0802a6bd91d"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -289,7 +355,9 @@
    "metadata": {
     "tags": []
    },
-   "source": "Interactive([visium_sdata, xenium_sdata])"
+   "source": [
+    "Interactive([visium_sdata, xenium_sdata])"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -462,7 +530,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   },
   "vscode": {
    "interpreter": {

--- a/notebooks/examples/alignment_using_landmarks.ipynb
+++ b/notebooks/examples/alignment_using_landmarks.ipynb
@@ -38,146 +38,58 @@
    ]
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "9b33ec76",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-04-10T18:53:42.780777Z",
-     "start_time": "2023-04-10T18:53:42.778038Z"
-    },
-    "tags": []
-   },
    "outputs": [],
+   "execution_count": null,
    "source": [
     "import numpy as np\n",
     "import spatialdata as sd\n",
-    "\n",
-    "# from napari_spatialdata import Interactive"
-   ]
+    "from napari_spatialdata import Interactive"
+   ],
+   "id": "1f53261205fc9441"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "74cb18bf",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-04-10T16:39:12.804097Z",
-     "start_time": "2023-04-10T16:39:09.756352Z"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/macbook/miniconda3/envs/ome/lib/python3.10/site-packages/anndata/_core/anndata.py:183: ImplicitModificationWarning: Transforming to str index.\n",
-      "  warnings.warn(\"Transforming to str index.\", ImplicitModificationWarning)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "SpatialData object, with associated Zarr store: /Users/macbook/embl/projects/basel/spatialdata-sandbox/xenium_rep1_io/data.zarr\n",
-       "├── Images\n",
-       "│     ├── 'morphology_focus': MultiscaleSpatialImage[cyx] (1, 25778, 35416), (1, 12889, 17708), (1, 6444, 8854), (1, 3222, 4427), (1, 1611, 2213)\n",
-       "│     └── 'morphology_mip': MultiscaleSpatialImage[cyx] (1, 25778, 35416), (1, 12889, 17708), (1, 6444, 8854), (1, 3222, 4427), (1, 1611, 2213)\n",
-       "├── Labels\n",
-       "│     ├── 'cell_labels': MultiscaleSpatialImage[yx] (25778, 35416), (12889, 17708), (6444, 8854), (3222, 4427), (1611, 2213)\n",
-       "│     └── 'nucleus_labels': MultiscaleSpatialImage[yx] (25778, 35416), (12889, 17708), (6444, 8854), (3222, 4427), (1611, 2213)\n",
-       "├── Points\n",
-       "│     └── 'transcripts': DataFrame with shape: (42638083, 8) (3D points)\n",
-       "├── Shapes\n",
-       "│     ├── 'cell_boundaries': GeoDataFrame shape: (167780, 1) (2D shapes)\n",
-       "│     ├── 'cell_circles': GeoDataFrame shape: (167780, 2) (2D shapes)\n",
-       "│     └── 'nucleus_boundaries': GeoDataFrame shape: (167780, 1) (2D shapes)\n",
-       "└── Tables\n",
-       "      └── 'table': AnnData (167780, 313)\n",
-       "with coordinate systems:\n",
-       "    ▸ 'global', with elements:\n",
-       "        morphology_focus (Images), morphology_mip (Images), cell_labels (Labels), nucleus_labels (Labels), transcripts (Points), cell_boundaries (Shapes), cell_circles (Shapes), nucleus_boundaries (Shapes)"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "xenium_sdata = sd.read_zarr(\"xenium.zarr\")\n",
     "xenium_sdata"
-   ]
+   ],
+   "id": "b688e9cd77be1055"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "53b923aa",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-04-10T16:39:26.103792Z",
-     "start_time": "2023-04-10T16:39:25.844959Z"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "SpatialData object, with associated Zarr store: /Users/macbook/embl/projects/basel/spatialdata-sandbox/visium_associated_xenium_io/data.zarr\n",
-       "├── Images\n",
-       "│     ├── 'CytAssist_FFPE_Human_Breast_Cancer_full_image': MultiscaleSpatialImage[cyx] (3, 21571, 19505), (3, 10785, 9752), (3, 5392, 4876), (3, 2696, 2438), (3, 1348, 1219)\n",
-       "│     ├── 'CytAssist_FFPE_Human_Breast_Cancer_hires_image': SpatialImage[cyx] (3, 2000, 1809)\n",
-       "│     └── 'CytAssist_FFPE_Human_Breast_Cancer_lowres_image': SpatialImage[cyx] (3, 600, 543)\n",
-       "├── Shapes\n",
-       "│     └── 'CytAssist_FFPE_Human_Breast_Cancer': GeoDataFrame shape: (4992, 2) (2D shapes)\n",
-       "└── Tables\n",
-       "      └── 'table': AnnData (4992, 18085)\n",
-       "with coordinate systems:\n",
-       "    ▸ 'aligned', with elements:\n",
-       "        CytAssist_FFPE_Human_Breast_Cancer_full_image (Images), CytAssist_FFPE_Human_Breast_Cancer (Shapes)\n",
-       "    ▸ 'downscaled_hires', with elements:\n",
-       "        CytAssist_FFPE_Human_Breast_Cancer_hires_image (Images), CytAssist_FFPE_Human_Breast_Cancer (Shapes)\n",
-       "    ▸ 'downscaled_lowres', with elements:\n",
-       "        CytAssist_FFPE_Human_Breast_Cancer_lowres_image (Images), CytAssist_FFPE_Human_Breast_Cancer (Shapes)\n",
-       "    ▸ 'global', with elements:\n",
-       "        CytAssist_FFPE_Human_Breast_Cancer_full_image (Images), CytAssist_FFPE_Human_Breast_Cancer (Shapes)"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "visium_sdata = sd.read_zarr(\"visium.zarr\")\n",
     "visium_sdata"
-   ]
+   ],
+   "id": "934577dfc660308c"
   },
   {
-   "cell_type": "markdown",
-   "id": "2fa12f3a",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "Let's visualize the data with napari.\n",
     "\n",
     "*Note: we are working with the napari developers to improve performance when visualizing large collections of geometries. For the sake of this example let's just show the Xenium and Visium images.*"
-   ]
+   ],
+   "id": "12c5b4809c9be7ec"
   },
   {
-   "cell_type": "raw",
-   "id": "50de9933-ed3a-4061-96e5-444981f5bdbc",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-04-10T18:59:26.909684Z",
-     "start_time": "2023-04-10T18:59:25.642148Z"
-    },
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
-   },
-   "source": "Interactive([visium_sdata, xenium_sdata])"
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "Interactive([visium_sdata, xenium_sdata])"
+   ],
+   "id": "cc89e0802a6bd91d"
   },
   {
    "cell_type": "markdown",
@@ -211,7 +123,11 @@
     "4. (optional) change the color and points size for easier visualization\n",
     "5. click to add the annotation point\n",
     "6. (optional) use the `napari` functions to move/delete points\n",
-    "7. save the annotation to the `SpatialData` object by pressing `Shift + E` (if you called `Interactive()` passing multiple `SpatialData` objects, the annotations will be saved to one of them).\n"
+    "7. Since we have more than 1 `SpatialData` object open in the viewer, we need to link the new layer to the `SpatialData` \n",
+    "object it should be added to. Select both the new layer and a layer already linked to a `SpatialData` object and press\n",
+    "`Shift + L`. A message will pop up stating `layer linked to ...` indicating success of linking the new layer to\n",
+    "`SpatialData` object.\n",
+    "8. save the annotation to the `SpatialData` object by pressing `Shift + E` (if you called `Interactive()` passing multiple `SpatialData` objects, the annotations will be saved to one of them).\n"
    ]
   },
   {


### PR DESCRIPTION
There was no instruction in the alignment notebook to first link the layer to a layer that is already linked to a `SpatialData` object. This would result in the notebook not working. Given that multipole sdata objects are active in the viewer the export would fail.