### PR TITLE
fix visium_hd

### DIFF
--- a/notebooks/examples/technology_visium_hd.ipynb
+++ b/notebooks/examples/technology_visium_hd.ipynb
@@ -190,7 +190,9 @@
    "source": [
     "from spatialdata import get_extent\n",
     "\n",
-    "data_extent = get_extent(sdata[\"Visium_HD_Mouse_Small_Intestine_full_image\"], coordinate_system=\"global\")\n",
+    "data_extent = get_extent(\n",
+    "    sdata[\"Visium_HD_Mouse_Small_Intestine_full_image\"], coordinate_system=\"Visium_HD_Mouse_Small_Intestine\"\n",
+    ")\n",
     "data_extent"
    ]
   },
@@ -208,7 +210,7 @@
     "    min_coordinate=[data_extent[\"x\"][0], data_extent[\"y\"][0]],\n",
     "    max_coordinate=[data_extent[\"x\"][1], data_extent[\"y\"][1]],\n",
     "    axes=(\"x\", \"y\"),\n",
-    "    target_coordinate_system=\"global\",\n",
+    "    target_coordinate_system=\"Visium_HD_Mouse_Small_Intestine\",\n",
     ")\n",
     "sdata[\"queried_cytassist\"] = queried_cytassist"
    ]
@@ -254,10 +256,10 @@
     "\n",
     "\n",
     "crop0(sdata).pl.render_images(\"Visium_HD_Mouse_Small_Intestine_full_image\").pl.show(\n",
-    "    ax=axes[0], title=\"Full image\", coordinate_systems=\"global\"\n",
+    "    ax=axes[0], title=\"Full image\", coordinate_systems=\"Visium_HD_Mouse_Small_Intestine\"\n",
     ")\n",
     "crop0(sdata).pl.render_images(\"queried_cytassist\").pl.show(\n",
-    "    ax=axes[1], title=\"CytAssit image\", coordinate_systems=\"global\"\n",
+    "    ax=axes[1], title=\"CytAssit image\", coordinate_systems=\"Visium_HD_Mouse_Small_Intestine\"\n",
     ")"
    ]
   },
@@ -601,7 +603,7 @@
     "gene_name = \"AA986860\"\n",
     "\n",
     "for bin_size in [16, 8]:\n",
-    "    sdata_small.pl.render_images(\"Visium_HD_Mouse_Small_Intestine_hires_image\").pl.render_shapes(\n",
+    "    sdata_small.pl.render_images(\"Visium_HD_Mouse_Small_Intestine_full_image\").pl.render_shapes(\n",
     "        f\"Visium_HD_Mouse_Small_Intestine_square_{bin_size:03}um\", color=gene_name, cmap=new_cmap\n",
     "    ).pl.show(coordinate_systems=\"Visium_HD_Mouse_Small_Intestine\", title=f\"bin_size={bin_size}µm\", figsize=(10, 10))"
    ]
@@ -641,7 +643,7 @@
     "    )\n",
     "\n",
     "\n",
-    "crop1(sdata_small).pl.render_images(\"Visium_HD_Mouse_Small_Intestine_hires_image\").pl.render_shapes(\n",
+    "crop1(sdata_small).pl.render_images(\"Visium_HD_Mouse_Small_Intestine_full_image\").pl.render_shapes(\n",
     "    \"Visium_HD_Mouse_Small_Intestine_square_002um\", color=gene_name, cmap=new_cmap, method=\"matplotlib\"\n",
     ").pl.show(coordinate_systems=\"Visium_HD_Mouse_Small_Intestine\", title=\"bin_size=2µm\", figsize=(10, 10))"
    ]
@@ -772,7 +774,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "crop1(sdata).pl.render_images(\"Visium_HD_Mouse_Small_Intestine_hires_image\").pl.render_shapes(\n",
+    "crop0(sdata).pl.render_images(\"Visium_HD_Mouse_Small_Intestine_full_image\").pl.render_shapes(\n",
     "    \"Visium_HD_Mouse_Small_Intestine_square_016um\", color=\"Cluster\"\n",
     ").pl.show(coordinate_systems=\"Visium_HD_Mouse_Small_Intestine\", title=\"bin_size=016µm\", figsize=(10, 10))"
    ]

--- a/notebooks/examples/technology_visium_hd.ipynb
+++ b/notebooks/examples/technology_visium_hd.ipynb
@@ -56,15 +56,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "4c059777-0354-4ed7-a848-14e442ca34af",
    "metadata": {},
-   "outputs": [],
    "source": [
     "%load_ext jupyter_black\n",
     "%load_ext autoreload\n",
     "%autoreload 2"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -88,13 +88,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "3f1bd970-13dc-444b-ae61-6d9bf844de4b",
    "metadata": {},
-   "outputs": [],
    "source": [
     "visium_hd_zarr_path = \"./visium_hd.zarr\""
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -106,10 +106,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "af93b905-28fb-4167-b765-059c148ca3bc",
    "metadata": {},
-   "outputs": [],
    "source": [
     "%%time\n",
     "import spatialdata as sd\n",
@@ -117,7 +115,9 @@
     "\n",
     "sdata = sd.read_zarr(visium_hd_zarr_path)\n",
     "sdata"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -131,15 +131,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "4f548a36-14e1-4055-b738-20b3be502bb1",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# let's make the var names unique; this improves performance in accessing the tabular data and is necessary to be able to plot the data\n",
     "for table in sdata.tables.values():\n",
     "    table.var_names_make_unique()"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -159,17 +159,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "88f696a8-4761-4bd0-b1f0-1b16edcdf726",
    "metadata": {},
-   "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
     "axes = plt.subplots(1, 2, figsize=(10, 5))[1].flatten()\n",
     "sdata.pl.render_images(\"Visium_HD_Mouse_Small_Intestine_full_image\").pl.show(ax=axes[0], title=\"Full image\")\n",
     "sdata.pl.render_images(\"Visium_HD_Mouse_Small_Intestine_cytassist_image\").pl.show(ax=axes[1], title=\"CytAssit image\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -183,10 +183,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "9ef57701-7920-49ef-a2d6-fed3457289c8",
    "metadata": {},
-   "outputs": [],
    "source": [
     "from spatialdata import get_extent\n",
     "\n",
@@ -194,14 +192,14 @@
     "    sdata[\"Visium_HD_Mouse_Small_Intestine_full_image\"], coordinate_system=\"Visium_HD_Mouse_Small_Intestine\"\n",
     ")\n",
     "data_extent"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "c0157c6a-8b5a-4f83-bcd8-069ce45ee5fc",
    "metadata": {},
-   "outputs": [],
    "source": [
     "from spatialdata import bounding_box_query\n",
     "\n",
@@ -213,19 +211,21 @@
     "    target_coordinate_system=\"Visium_HD_Mouse_Small_Intestine\",\n",
     ")\n",
     "sdata[\"queried_cytassist\"] = queried_cytassist"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "178cb07a-6f8c-4fc3-9bb6-9447490d031a",
    "metadata": {},
-   "outputs": [],
    "source": [
     "axes = plt.subplots(1, 2, figsize=(10, 5))[1].flatten()\n",
     "sdata.pl.render_images(\"Visium_HD_Mouse_Small_Intestine_full_image\").pl.show(ax=axes[0], title=\"Full image\")\n",
     "sdata.pl.render_images(\"queried_cytassist\").pl.show(ax=axes[1], title=\"CytAssit image\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -237,10 +237,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "426bcaca-903c-418e-8b37-721ec20e89b6",
    "metadata": {},
-   "outputs": [],
    "source": [
     "axes = plt.subplots(1, 2, figsize=(10, 5))[1].flatten()\n",
     "\n",
@@ -251,7 +249,7 @@
     "        min_coordinate=[5000, 8000],\n",
     "        max_coordinate=[10000, 13000],\n",
     "        axes=(\"x\", \"y\"),\n",
-    "        target_coordinate_system=\"global\",\n",
+    "        target_coordinate_system=\"Visium_HD_Mouse_Small_Intestine\",\n",
     "    )\n",
     "\n",
     "\n",
@@ -261,7 +259,9 @@
     "crop0(sdata).pl.render_images(\"queried_cytassist\").pl.show(\n",
     "    ax=axes[1], title=\"CytAssit image\", coordinate_systems=\"Visium_HD_Mouse_Small_Intestine\"\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -299,10 +299,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "718adc98-3cad-4f7d-b132-674a81de556a",
    "metadata": {},
-   "outputs": [],
    "source": [
     "%%time\n",
     "plt.figure(figsize=(10, 10))\n",
@@ -312,7 +310,9 @@
     "sdata.pl.render_shapes(\"Visium_HD_Mouse_Small_Intestine_square_016um\", color=gene_name, method=\"datashader\").pl.show(\n",
     "    coordinate_systems=\"Visium_HD_Mouse_Small_Intestine\", ax=ax\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -332,10 +332,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "7bc79afa-c01e-4d81-9426-b3dd4a0faf71",
    "metadata": {},
-   "outputs": [],
    "source": [
     "%%time\n",
     "from spatialdata import rasterize_bins\n",
@@ -351,7 +349,9 @@
     "        \"array_row\",\n",
     "    )\n",
     "    sdata[f\"rasterized_{bin_size}um\"] = rasterized"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -365,27 +365,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "f0a80c44-062f-4082-8cc5-25272d8e0320",
    "metadata": {},
-   "outputs": [],
    "source": [
     "%%time\n",
     "# this is very fast\n",
     "sdata[\"rasterized_002um\"].sel(c=gene_name).compute()\n",
     "# this must not be called\n",
     "# sdata[\"rasterized_002um\"].compute()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "858e4693485c0dc1",
-   "metadata": {},
+   ],
    "outputs": [],
-   "source": [
-    "sdata"
-   ]
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -398,10 +388,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "94ae33c7-1181-4655-a994-23494215b74d",
    "metadata": {},
-   "outputs": [],
    "source": [
     "%%time\n",
     "plt.figure(figsize=(10, 10))\n",
@@ -410,7 +398,9 @@
     "sdata.pl.render_images(\"rasterized_016um\", channel=gene_name, scale=\"full\").pl.show(\n",
     "    coordinate_systems=\"Visium_HD_Mouse_Small_Intestine\", ax=ax\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -428,10 +418,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "9f3f00f9-dfb3-4fad-8f45-7e4aab8b06c1",
    "metadata": {},
-   "outputs": [],
    "source": [
     "%%time\n",
     "\n",
@@ -448,14 +436,14 @@
     "        plt.xlim([14000, 15000])\n",
     "        plt.ylim([14000, 15000])\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "9e2d24e8-0e62-4c28-b520-a7284c77ea16",
    "metadata": {},
-   "outputs": [],
    "source": [
     "from matplotlib.colors import ListedColormap\n",
     "\n",
@@ -477,7 +465,9 @@
     "plt.colorbar()\n",
     "\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -507,10 +497,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "5ffd4223-8f99-4efb-9393-3946e54f1a92",
    "metadata": {},
-   "outputs": [],
    "source": [
     "sdata_small = sdata.query.bounding_box(\n",
     "    min_coordinate=[7000, 11000],\n",
@@ -518,20 +506,22 @@
     "    axes=(\"x\", \"y\"),\n",
     "    target_coordinate_system=\"Visium_HD_Mouse_Small_Intestine\",\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "96961629-93e0-4048-8f66-8d40884a423e",
    "metadata": {},
-   "outputs": [],
    "source": [
     "gene_name = \"AA986860\"\n",
     "sdata_small.pl.render_shapes(\"Visium_HD_Mouse_Small_Intestine_square_016um\", color=gene_name).pl.show(\n",
     "    coordinate_systems=\"Visium_HD_Mouse_Small_Intestine\"\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -543,23 +533,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "8cc72c90-62ea-44bf-a867-126ed5cf5c39",
    "metadata": {},
-   "outputs": [],
    "source": [
     "gene_name = \"AA986860\"\n",
     "sdata_small.pl.render_shapes(\n",
     "    \"Visium_HD_Mouse_Small_Intestine_square_016um\", color=gene_name, method=\"datashader\"\n",
     ").pl.show(coordinate_systems=\"Visium_HD_Mouse_Small_Intestine\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "bd05c2a6-b7db-463c-bd1c-6f635bd0b893",
    "metadata": {},
-   "outputs": [],
    "source": [
     "gene_name = \"AA986860\"\n",
     "\n",
@@ -569,7 +557,9 @@
     "        color=gene_name,\n",
     "        method=\"datashader\",\n",
     "    ).pl.show(coordinate_systems=\"Visium_HD_Mouse_Small_Intestine\", title=f\"bin_size={bin_size}µm\", figsize=(10, 10))"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -583,22 +573,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "40ad666f-6880-42be-82e7-b43d8f665108",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# let's display the areas where no expression is detected as transparent\n",
     "new_cmap = set_zero_in_cmap_to_transparent(cmap=\"viridis\")\n",
     "new_cmap"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "b62c1c6b-b58c-4f52-a516-b1e36ed0a0b6",
    "metadata": {},
-   "outputs": [],
    "source": [
     "gene_name = \"AA986860\"\n",
     "\n",
@@ -606,17 +594,19 @@
     "    sdata_small.pl.render_images(\"Visium_HD_Mouse_Small_Intestine_full_image\").pl.render_shapes(\n",
     "        f\"Visium_HD_Mouse_Small_Intestine_square_{bin_size:03}um\", color=gene_name, cmap=new_cmap\n",
     "    ).pl.show(coordinate_systems=\"Visium_HD_Mouse_Small_Intestine\", title=f\"bin_size={bin_size}µm\", figsize=(10, 10))"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "3fcb1d4cbcb037ba",
    "metadata": {},
-   "outputs": [],
    "source": [
     "sdata_small"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -628,10 +618,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "31a66a54-13ed-489c-805d-dcecfd53959a",
    "metadata": {},
-   "outputs": [],
    "source": [
     "def crop1(x):\n",
     "    return bounding_box_query(\n",
@@ -646,7 +634,9 @@
     "crop1(sdata_small).pl.render_images(\"Visium_HD_Mouse_Small_Intestine_full_image\").pl.render_shapes(\n",
     "    \"Visium_HD_Mouse_Small_Intestine_square_002um\", color=gene_name, cmap=new_cmap, method=\"matplotlib\"\n",
     ").pl.show(coordinate_systems=\"Visium_HD_Mouse_Small_Intestine\", title=\"bin_size=2µm\", figsize=(10, 10))"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -674,10 +664,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "2fa822ad-87ec-46c0-a8fb-6df8d058be18",
    "metadata": {},
-   "outputs": [],
    "source": [
     "import os\n",
     "from tempfile import TemporaryDirectory\n",
@@ -695,39 +683,41 @@
     "    with open(path, \"wb\") as f:\n",
     "        f.write(response.content)\n",
     "    df = pd.read_csv(path)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "455b85fc-69a3-4bf8-9660-ff391a6c9652",
    "metadata": {},
-   "outputs": [],
    "source": [
     "df.head(3)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "d8efead2-f57c-4895-bcd6-4730a2ad7a73",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# let's convert the Cluster dtype from int64 to categorical since later we want the plots to use a categorical colormap\n",
     "df[\"Cluster\"] = df[\"Cluster\"].astype(\"category\")\n",
     "df.set_index(\"Barcode\", inplace=True)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "178addbb-1146-4fb9-830a-a21cb64355b9",
    "metadata": {},
-   "outputs": [],
    "source": [
     "sdata[\"square_016um\"].obs.head(3)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -739,24 +729,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "1dea8dc9-81f4-47cc-98da-bd5b5e56efb6",
    "metadata": {},
-   "outputs": [],
    "source": [
     "sdata[\"square_016um\"].obs[\"Cluster\"] = df[\"Cluster\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dd54a16f4b57c5ae",
-   "metadata": {},
+   ],
    "outputs": [],
-   "source": [
-    "b = crop1(sdata)\n",
-    "b"
-   ]
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -768,16 +747,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "adda971f-9a32-43af-b216-10e78fb86731",
    "metadata": {},
-   "outputs": [],
    "source": [
     "%%time\n",
     "crop0(sdata).pl.render_images(\"Visium_HD_Mouse_Small_Intestine_full_image\").pl.render_shapes(\n",
     "    \"Visium_HD_Mouse_Small_Intestine_square_016um\", color=\"Cluster\"\n",
     ").pl.show(coordinate_systems=\"Visium_HD_Mouse_Small_Intestine\", title=\"bin_size=016µm\", figsize=(10, 10))"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
This PR is dependent on https://github.com/scverse/spatialdata-plot/pull/446. Furthermore, the gene expression data is in a different coordinate system now, namely `Visium_HD_Mouse_Small_Intestine`. This coordinate system does not have the image elment `Visium_HD_Mouse_Small_Intestine_full_image` anymore. This element is only present in `global`. This PR therefore uses in that case `Visium_HD_Mouse_Small_Intestine_hires_image` instead. 

This makes it so that the notebook can run, but some of the resulting plots have changed as a result. @LucaMarconato is the change of where element live intended and thus this PR is ok, or is this actually showing an issue in the visiumhd reader?